### PR TITLE
Fix font path on Android

### DIFF
--- a/android/src/main/kotlin/com/iproov/sdk/IProovSDKPlugin.kt
+++ b/android/src/main/kotlin/com/iproov/sdk/IProovSDKPlugin.kt
@@ -192,6 +192,6 @@ class IProovSDKPlugin: FlutterPlugin {
 
     private fun getFontPath(assetPath: String): String {
         val loader = FlutterInjector.instance().flutterLoader()
-        return loader.getLookupKeyForAsset("fonts/Lobster-Regular.ttf")
+        return loader.getLookupKeyForAsset(assetPath)
     }
 }


### PR DESCRIPTION
Using `options.ui.fontPath` crashes the app on Android, because the provided fontPath is ignored and hardcoded `"fonts/Lobster-Regular.ttf"` is used instead (which is not found and app crashes).