### PR TITLE
Fix certificates encoding in NetworkOptions

### DIFF
--- a/lib/options.dart
+++ b/lib/options.dart
@@ -93,7 +93,7 @@ class NetworkOptions {
   String? path;
 
   Map<String, dynamic> toJson() => removeNulls({
-        'certificates': certificates?.map((e) => base64.encode(e)),
+        'certificates': certificates?.map((e) => base64.encode(e)).toList(),
         'timeout': timeout?.inSeconds,
         'path': path
       });


### PR DESCRIPTION
Received following error when providing `options.network.certificates`: `Unhandled Exception: Converting object to an encodable object failed: Instance of 'Options'`

Reason is that `toList()` is missing after certificates are mapped to convert from bytes to base64.